### PR TITLE
Try to clone 'main' first.

### DIFF
--- a/pkg/tpkg/registry.go
+++ b/pkg/tpkg/registry.go
@@ -343,6 +343,10 @@ func (gr *gitRegistry) Load(ctx context.Context, sync bool, cache Cache, ui UI) 
 			url := gr.url
 
 			var err error
+			// The go-git library doesn't support cloning repositories that use 'main' as
+			// default branch: https://github.com/go-git/go-git/issues/363
+			// We therefore try different ones.
+			// It's advantageous to try the correct one first.
 			for _, branch := range []string{"main", "master", "trunk"} {
 				_, err = git.Clone(ctx, p, git.CloneOptions{
 					URL:          url,

--- a/pkg/tpkg/registry.go
+++ b/pkg/tpkg/registry.go
@@ -343,7 +343,7 @@ func (gr *gitRegistry) Load(ctx context.Context, sync bool, cache Cache, ui UI) 
 			url := gr.url
 
 			var err error
-			for _, branch := range []string{"master", "main", "trunk"} {
+			for _, branch := range []string{"main", "master", "trunk"} {
 				_, err = git.Clone(ctx, p, git.CloneOptions{
 					URL:          url,
 					SingleBranch: true,


### PR DESCRIPTION
The git-library doesn't support cloning repositories that use 'main' as
default branch: https://github.com/go-git/go-git/issues/363

We therefore try 'main', 'master' and 'trunk'.

Until now we tried 'master' first, but since the Toit registry already
uses 'main' that leads to an unnecessary clone-attempt. It also allows a
race condition where another toit.pkg command could try to pull the
'master' branch.