### PR TITLE
Protect against synchronizing registries in parallel

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.15
 
 require (
 	github.com/alessio/shellescape v1.4.1
+	github.com/alexflint/go-filemutex v1.1.0 // indirect
 	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/gobwas/glob v0.2.3

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
 github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
+github.com/alexflint/go-filemutex v1.1.0 h1:IAWuUuRYL2hETx5b8vCgwnD+xSdlsTQY6s2JjBsqLdg=
+github.com/alexflint/go-filemutex v1.1.0/go.mod h1:7P4iRhttt/nUvUOrYIhcpMzv2G6CY9UnI16Z+UJqRyk=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=

--- a/pkg/tpkg/registry.go
+++ b/pkg/tpkg/registry.go
@@ -21,7 +21,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
+	"github.com/alexflint/go-filemutex"
 	"github.com/gobwas/glob"
 	"github.com/toitlang/tpkg/pkg/git"
 )
@@ -337,9 +339,54 @@ func (gr *gitRegistry) Describe() string {
 
 func (gr *gitRegistry) Load(ctx context.Context, sync bool, cache Cache, ui UI) error {
 	if sync {
+		p := gr.path
+		if gr.path == "" {
+			p = cache.PreferredRegistryPath(gr.url)
+		}
+
+		// Make sure only one pkg-manager is loading the registry at the same time.
+		// Use a lock file in the directory above the registry's checkout path.
+		// This way we don't interfere with cloning/pulling, but still have relatively
+		// good granularity, allowing to sync multiple registries at the same time.
+		lockP := filepath.Join(filepath.Dir(p), ".tpgk_sync.lock")
+		err := os.MkdirAll(filepath.Dir(lockP), 0755)
+		if err != nil {
+			return err
+		}
+		m, err := filemutex.New(lockP)
+		if err != nil {
+			println("Error is here")
+			return err
+		}
+
+		unlocked := make(chan struct{})
+		ctx, cancel := context.WithTimeout(ctx, time.Second*10)
+		defer cancel()
+
+		// The following has a race condition:
+		// We could get the lock, then enter the `default` select, but before
+		// closing the channel, the ctx is done and the second select becomes
+		// non-deterministic.
+		// In that case we don't even unlock anymore.
+		// It's a bad case, but better than not giving any error-message.
+		go func() {
+			m.Lock()
+			select {
+			case <-ctx.Done():
+				m.Unlock()
+			default:
+				close(unlocked)
+			}
+		}()
+		select {
+		case <-unlocked:
+			defer m.Unlock()
+		case <-ctx.Done():
+			return fmt.Errorf("unable to acquire sync lock %s", lockP)
+		}
+
 		if gr.path == "" {
 
-			p := cache.PreferredRegistryPath(gr.url)
 			url := gr.url
 
 			var err error
@@ -363,11 +410,10 @@ func (gr *gitRegistry) Load(ctx context.Context, sync bool, cache Cache, ui UI) 
 			}
 			gr.pathRegistry.path = p
 		} else {
-			err := git.Pull(gr.path, git.PullOptions{})
+			err := git.Pull(p, git.PullOptions{})
 			if err != nil {
 				return err
 			}
-
 		}
 	}
 	if gr.path == "" {


### PR DESCRIPTION
Use a file-lock to ensure that only one tpkg instance synchronizes a
registry.