### PR TITLE
Fix install for local deps with slashes at end

### DIFF
--- a/pkg/tpkg/spec.go
+++ b/pkg/tpkg/spec.go
@@ -244,8 +244,9 @@ func (s *Spec) BuildLockFile(solution *Solution, cache Cache, registries Registr
 			p := specPkg.Path.FilePath()
 			fullPath := p
 			if !filepath.IsAbs(fullPath) {
-				fullPath = filepath.Clean(filepath.Join(dir, p))
+				fullPath = filepath.Join(dir, p)
 			}
+			fullPath = filepath.Clean(fullPath)
 			targetID, ok := localPkgIDs[fullPath]
 			if !ok {
 				targetID = fmt.Sprintf("localPkg%d", idCounter)

--- a/tests/assets/pkg/InstallAbsLocal/gold/test.gold
+++ b/tests/assets/pkg/InstallAbsLocal/gold/test.gold
@@ -9,9 +9,9 @@ prefixes:
   gee: slash
 packages:
   path:
-    path: /some/abs/path
+    path: /c:/some/abs/path
   slash:
-    path: /some/other/abs/path/with/slash
+    path: /c:/some/other/abs/path/with/slash
   xxx:
     path: xxx
 

--- a/tests/assets/pkg/InstallAbsLocal/gold/test.gold
+++ b/tests/assets/pkg/InstallAbsLocal/gold/test.gold
@@ -1,0 +1,17 @@
+pkg install
+Exit Code: 0
+===================
+pkg lockfile
+Exit Code: 0
+prefixes:
+  bar: path
+  foo: xxx
+  gee: slash
+packages:
+  path:
+    path: /some/abs/path
+  slash:
+    path: /some/other/abs/path/with/slash
+  xxx:
+    path: xxx
+

--- a/tests/assets/pkg/InstallAbsLocal/package.yaml
+++ b/tests/assets/pkg/InstallAbsLocal/package.yaml
@@ -1,0 +1,7 @@
+dependencies:
+  foo:
+    path: xxx
+  bar:
+    path: /some/abs/path
+  gee:
+    path: /some/other/abs/path/with/slash/

--- a/tests/assets/pkg/InstallAbsLocal/package.yaml
+++ b/tests/assets/pkg/InstallAbsLocal/package.yaml
@@ -2,6 +2,6 @@ dependencies:
   foo:
     path: xxx
   bar:
-    path: /some/abs/path
+    path: /c:/some/abs/path
   gee:
-    path: /some/other/abs/path/with/slash/
+    path: /c:/some/other/abs/path/with/slash/

--- a/tests/pkg_test.go
+++ b/tests/pkg_test.go
@@ -1012,6 +1012,13 @@ func test_toitPkg(t *tedi.T) {
 		})
 	})
 
+	t.Run("InstallAbsLocal", func(t *tedi.T, pt PkgTest) {
+		pt.GoldToit("test", [][]string{
+			{"pkg", "install"},
+			{"pkg", "lockfile"},
+		})
+	})
+
 	t.Run("RegistrySkipHidden", func(t *tedi.T, pt PkgTest) {
 		regPath := filepath.Join(pt.dir, "reg_with_hidden")
 		pt.GoldToit("test", [][]string{


### PR DESCRIPTION
When a package.yaml file had an absolute path with a slash at the end it was not correctly
handled during install, leading to mismatched IDs.