### PR TITLE
Add '--clear-cache' flag to the sync command

### DIFF
--- a/tests/assets/pkg/GitRegistryClearCache/gold/full-command.gold
+++ b/tests/assets/pkg/GitRegistryClearCache/gold/full-command.gold
@@ -1,0 +1,12 @@
+pkg registry sync --clear-cache
+Exit Code: 0
+Info: Syncing 'test-reg'
+===================
+pkg list
+Exit Code: 0
+test-reg: <TEST>/registry_git_pkgs:
+  pkg1 - 1.0.0
+  pkg2 - 1.0.0
+  pkg2 - 2.4.2
+  pkg3 - 3.1.2
+  pkg4 - 4.9.9

--- a/tests/assets/pkg/GitRegistryClearCache/gold/no-clear.gold
+++ b/tests/assets/pkg/GitRegistryClearCache/gold/no-clear.gold
@@ -1,0 +1,12 @@
+pkg registry sync
+Exit Code: 0
+Info: Syncing 'test-reg'
+===================
+pkg list
+Exit Code: 0
+test-reg: <TEST>/registry_git_pkgs:
+  pkg1 - 1.0.0
+  pkg2 - 1.0.0
+  pkg2 - 2.4.2
+  pkg3 - 3.1.2
+  pkg4 - 4.9.9

--- a/tests/assets/pkg/GitRegistryClearCache/gold/sync-alias.gold
+++ b/tests/assets/pkg/GitRegistryClearCache/gold/sync-alias.gold
@@ -1,0 +1,12 @@
+pkg sync --clear-cache
+Exit Code: 0
+Info: Syncing 'test-reg'
+===================
+pkg list
+Exit Code: 0
+test-reg: <TEST>/registry_git_pkgs:
+  pkg1 - 1.0.0
+  pkg2 - 1.0.0
+  pkg2 - 2.4.2
+  pkg3 - 3.1.2
+  pkg4 - 4.9.9

--- a/tests/assets/pkg/GitRegistryClearCache/gold/test-preamble.gold
+++ b/tests/assets/pkg/GitRegistryClearCache/gold/test-preamble.gold
@@ -1,0 +1,2 @@
+pkg registry add test-reg <TEST>/registry_git_pkgs
+Exit Code: 0


### PR DESCRIPTION
We sometimes encounter corrupted caches, and this way our users can easily recover.